### PR TITLE
Fix outline label in summaries workflow

### DIFF
--- a/src/workflows/summaries.js
+++ b/src/workflows/summaries.js
@@ -15,7 +15,7 @@ MODEL,
 pages[i].slice(0, 8000)
 );
 const page = pdf.getPages()[i];
-pdf.catalog.addOutline(Pg ${i + 1}: ${summary}, page.ref);
+  pdf.catalog.addOutline(`Pg ${i + 1}: ${summary}`, page.ref);
 }
 
 pdf.setTitle("Remediated PDF");


### PR DESCRIPTION
## Summary
- use a template literal when creating outline labels

## Testing
- `node --check src/workflows/summaries.js`
