### PR TITLE
Add PHP web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,25 @@ OPENAI_API_KEY in .env (billing-enabled)
 
 (Optional) Adobe PDF Accessibility API keys if you later extend the workflow.
 
+## Web server setup
+
+These files include a small PHP front end so the tool can run behind an
+Apache web server on Ubuntu. The PHP page uploads your PDF, then calls the
+CLI to generate the remediated version.
+
+1. Install dependencies:
+   ```bash
+   sudo apt update
+   sudo apt install apache2 php nodejs npm
+   ```
+2. Clone this repository somewhere Apache can read (e.g. `/var/www/html/pdf-remediation`).
+3. In the repository directory run:
+   ```bash
+   cp .env.example .env   # add your OpenAI key
+   npm install
+   ```
+4. Ensure the `web/` directory is served by Apache. If the repository lives
+   in `/var/www/html/pdf-remediation`, you can access `http://your-server/pdf-remediation/web/`.
+5. Upload a PDF using the form and download the remediated file when processing completes.
+
 MIT License · © 2025

--- a/web/index.php
+++ b/web/index.php
@@ -1,0 +1,48 @@
+<?php
+function run_cli($in, $out) {
+    $root = realpath(__DIR__ . '/..');
+    $cmd = sprintf(
+        'cd %s && node src/cli.js remediate --in %s --out %s --alt --tags --summaries 2>&1',
+        escapeshellarg($root),
+        escapeshellarg($in),
+        escapeshellarg($out)
+    );
+    return shell_exec($cmd);
+}
+
+$result = '';
+$download = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['pdf'])) {
+    $uploadDir = __DIR__ . '/uploads/';
+    if (!is_dir($uploadDir)) {
+        mkdir($uploadDir, 0777, true);
+    }
+    $inputPath = $uploadDir . basename($_FILES['pdf']['name']);
+    if (move_uploaded_file($_FILES['pdf']['tmp_name'], $inputPath)) {
+        $outputPath = $uploadDir . 'remediated_' . basename($_FILES['pdf']['name']);
+        $result = run_cli($inputPath, $outputPath);
+        $download = 'uploads/' . basename($outputPath);
+    } else {
+        $result = 'Failed to upload file.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>PDF Remediation</title>
+</head>
+<body>
+<h1>PDF Remediation</h1>
+<?php if ($download): ?>
+    <p>Processing complete. <a href="<?= htmlspecialchars($download) ?>">Download remediated PDF</a></p>
+    <pre><?= htmlspecialchars($result) ?></pre>
+<?php endif; ?>
+<form method="post" enctype="multipart/form-data">
+    <label>Select PDF file:</label>
+    <input type="file" name="pdf" accept="application/pdf" required>
+    <button type="submit">Upload & Remediate</button>
+</form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `web/index.php` to provide a basic browser upload form
- update README with Apache/PHP setup instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683e55ca3d908331a41bcbe8471eb12d