### PR TITLE
Fix pdfjs import

### DIFF
--- a/src/pdf.js
+++ b/src/pdf.js
@@ -1,9 +1,9 @@
 import { PDFDocument } from "pdf-lib";
-import pdfjs from "pdfjs-dist/legacy/build/pdf.js";
+import { getDocument } from "pdfjs-dist";
 
 /** Extract plaintext for every page using pdfjs-dist. */
 export async function extractTextPerPage(pdfBytes) {
-const doc = await pdfjs.getDocument({ data: pdfBytes }).promise;
+const doc = await getDocument({ data: pdfBytes }).promise;
 const out = [];
 for (let p = 1; p <= doc.numPages; p++) {
 const page = await doc.getPage(p);


### PR DESCRIPTION
## Summary
- import `getDocument` directly from `pdfjs-dist`

## Testing
- `node -c src/pdf.js`
- `node -c src/cli.js`
- `node -c src/workflows/altText.js`
- `node -c src/workflows/tagging.js`
- `node -c src/workflows/summaries.js`
- `node -c src/ai.js`


------
https://chatgpt.com/codex/tasks/task_e_683e64e2dd8c8331860ea9ee0dc78e1e