### PR TITLE
Fix pdf.js import for Node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Requirements on your machine
 Node 20+ and npm
 Runs on any OS where Node 20+ is available (Ubuntu, Debian, macOS, Windows, etc.)
 
+**Note:** The PDF.js library we rely on targets Node 22+. This project imports
+its `legacy` build so everything works on Node 20.
+
 Internet access for the OpenAI API
 
 OPENAI_API_KEY in .env (billing-enabled)

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -1,5 +1,9 @@
 import { PDFDocument } from "pdf-lib";
-import { getDocument } from "pdfjs-dist";
+// The default `pdfjs-dist` build targets modern runtimes and relies on
+// `Promise.withResolvers`, which is only available in Node 22+.
+// To remain compatible with Node 20 (as required by this project),
+// use the `legacy` build instead which includes a polyfill.
+import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
 
 /** Extract plaintext for every page using pdfjs-dist. */
 export async function extractTextPerPage(pdfBytes) {


### PR DESCRIPTION
## Summary
- import the legacy pdfjs build to support Node 20
- mention the legacy build in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683e69ab308083319d930501b99fc732