### PR TITLE
Fix missing pdf-lib outline method

### DIFF
--- a/src/pdf.js
+++ b/src/pdf.js
@@ -1,4 +1,11 @@
-import { PDFDocument } from "pdf-lib";
+import {
+  PDFDocument,
+  PDFName,
+  PDFDict,
+  PDFRef,
+  PDFHexString,
+  PDFNumber,
+} from "pdf-lib";
 // The default `pdfjs-dist` build targets modern runtimes and relies on
 // `Promise.withResolvers`, which is only available in Node 22+.
 // To remain compatible with Node 20 (as required by this project),
@@ -23,4 +30,47 @@ const res = page.node.Resources();
 const xo = res?.lookup("XObject");
 const ref = xo?.lookup(name);
 if (ref) ref.set("Alt", page.doc.context.obj(alt));
+}
+
+/** Create a top-level bookmark linked to the given page. */
+export function addOutline(pdf, title, pageRef) {
+  const ctx = pdf.context;
+  const cat = pdf.catalog;
+
+  let outlinesRef = cat.get(PDFName.of("Outlines"));
+  let outlines;
+  if (outlinesRef instanceof PDFRef) {
+    outlines = ctx.lookup(outlinesRef, PDFDict);
+  }
+  if (!outlines) {
+    outlines = ctx.obj({ Type: "Outlines", Count: 0 });
+    outlinesRef = ctx.register(outlines);
+    cat.set(PDFName.of("Outlines"), outlinesRef);
+  }
+
+  const dest = ctx.obj([pageRef, PDFName.of("Fit")]);
+  const item = ctx.obj({
+    Title: PDFHexString.fromText(title),
+    Parent: outlinesRef,
+    Dest: dest,
+  });
+  const itemRef = ctx.register(item);
+
+  const first = outlines.lookupMaybe(PDFName.of("First"), PDFRef);
+  if (!first) {
+    outlines.set(PDFName.of("First"), itemRef);
+    outlines.set(PDFName.of("Last"), itemRef);
+  } else {
+    const lastRef = outlines.lookup(PDFName.of("Last"), PDFRef);
+    const last = ctx.lookup(lastRef, PDFDict);
+    last.set(PDFName.of("Next"), itemRef);
+    item.set(PDFName.of("Prev"), lastRef);
+    outlines.set(PDFName.of("Last"), itemRef);
+  }
+
+  const countObj = outlines.lookupMaybe(PDFName.of("Count"), PDFNumber);
+  const count = countObj ? countObj.asNumber() : 0;
+  outlines.set(PDFName.of("Count"), PDFNumber.of(count + 1));
+
+  return itemRef;
 }

--- a/src/workflows/summaries.js
+++ b/src/workflows/summaries.js
@@ -1,5 +1,5 @@
 import { PDFDocument } from "pdf-lib";
-import { extractTextPerPage } from "../pdf.js";
+import { extractTextPerPage, addOutline } from "../pdf.js";
 import { chat } from "../ai.js";
 
 const MODEL = "gpt-4.1-nano";
@@ -15,7 +15,7 @@ MODEL,
 pages[i].slice(0, 8000)
 );
 const page = pdf.getPages()[i];
-  pdf.catalog.addOutline(`Pg ${i + 1}: ${summary}`, page.ref);
+  addOutline(pdf, `Pg ${i + 1}: ${summary}`, page.ref);
 }
 
 pdf.setTitle("Remediated PDF");

--- a/src/workflows/tagging.js
+++ b/src/workflows/tagging.js
@@ -1,5 +1,5 @@
 import { PDFDocument } from "pdf-lib";
-import { extractTextPerPage } from "../pdf.js";
+import { extractTextPerPage, addOutline } from "../pdf.js";
 import { chat } from "../ai.js";
 
 const MODEL = "gpt-4.1-nano"; // cheapest text tier
@@ -20,7 +20,7 @@ try { roles = JSON.parse(json); } catch { continue; }
 const page = pdf.getPages()[i];
 roles
   .filter(r => r.role === "H1" || r.role === "H2")
-  .forEach(r => pdf.catalog.addOutline(r.text.slice(0, 60), page.ref));
+  .forEach(r => addOutline(pdf, r.text.slice(0, 60), page.ref));
 
 }
 return pdf.save();


### PR DESCRIPTION
## Summary
- implement a helper to create outline (bookmark) entries
- use new helper in summaries and tagging workflows

## Testing
- `node src/cli.js --help`
- `node -c src/pdf.js`
- `node -c src/workflows/summaries.js`
- `node -c src/workflows/tagging.js`


------
https://chatgpt.com/codex/tasks/task_e_683e6c351c4083319cae0232d01edde0