### PR TITLE
Ensure PDF pages are tagged for accessibility

### DIFF
--- a/src/workflows/tagging.js
+++ b/src/workflows/tagging.js
@@ -1,4 +1,11 @@
-import { PDFDocument, PDFName, PDFDict } from "pdf-lib";
+import {
+  PDFDocument,
+  PDFName,
+  PDFDict,
+  PDFNumber,
+  PDFOperator,
+  PDFOperatorNames as Ops,
+} from "pdf-lib";
 import { extractTextPerPage, addOutline } from "../pdf.js";
 import { chat } from "../ai.js";
 
@@ -16,6 +23,8 @@ export async function addTagTree(pdfBytes) {
   pdf.catalog.set(PDFName.of("StructTreeRoot"), rootRef);
   pdf.catalog.set(PDFName.of("MarkInfo"), ctx.obj({ Marked: true }));
 
+  const parentNums = [];
+
   for (let i = 0; i < pages.length; i++) {
     const raw = pages[i].slice(0, 8000);
     const json = await chat(
@@ -28,11 +37,45 @@ export async function addTagTree(pdfBytes) {
 
     const page = pdf.getPages()[i];
     page.node.set(PDFName.of("StructParents"), ctx.obj(i));
-    const pageElem = ctx.obj({ Type: "StructElem", S: PDFName.of("Div"), Pg: page.ref, P: rootRef });
+    const pageElem = ctx.obj({
+      Type: "StructElem",
+      S: PDFName.of("Div"),
+      Pg: page.ref,
+      P: rootRef,
+    });
     const pageKids = ctx.obj([]);
     pageElem.set(PDFName.of("K"), pageKids);
     const pageRef = ctx.register(pageElem);
     kids.push(pageRef);
+
+    // Wrap existing page content in a marked-content sequence
+    const start = ctx.contentStream([
+      PDFOperator.of(Ops.BeginMarkedContentSequence, [
+        PDFName.of("P"),
+        ctx.obj({ MCID: PDFNumber.of(0) }),
+      ]),
+    ]);
+    const end = ctx.contentStream([
+      PDFOperator.of(Ops.EndMarkedContent),
+    ]);
+    const startRef = ctx.register(start);
+    const endRef = ctx.register(end);
+    if (!page.node.wrapContentStreams(startRef, endRef)) {
+      const contents = page.node.Contents();
+      const arr = ctx.obj([startRef, contents, endRef]);
+      page.node.set(PDFName.of("Contents"), arr);
+    }
+
+    const pElem = ctx.obj({
+      Type: "StructElem",
+      S: PDFName.of("P"),
+      Pg: page.ref,
+      P: pageRef,
+      K: PDFNumber.of(0),
+    });
+    const pRef = ctx.register(pElem);
+    pageKids.push(pRef);
+    parentNums.push(PDFNumber.of(i), ctx.obj([pRef]));
 
     const res = page.node.Resources();
     const xo = res?.lookup("XObject");
@@ -62,10 +105,13 @@ export async function addTagTree(pdfBytes) {
       }
     }
 
-    roles
-      .filter(r => r.role === "H1" || r.role === "H2")
-      .forEach(r => addOutline(pdf, r.text.slice(0, 60), page.ref));
+      roles
+        .filter(r => r.role === "H1" || r.role === "H2")
+        .forEach(r => addOutline(pdf, r.text.slice(0, 60), page.ref));
   }
+
+  const parentTree = ctx.obj({ Nums: ctx.obj(parentNums) });
+  root.set(PDFName.of("ParentTree"), ctx.register(parentTree));
 
   return pdf.save();
 }


### PR DESCRIPTION
## Summary
- Wrap each page's content stream in a marked-content sequence and create corresponding paragraph structure elements
- Build a parent tree linking StructParents to MCID-tagged elements
- Register MarkInfo and ParentTree so text and path objects are tagged

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b1b754b94483318e7b5ca7ebf40f8f