### PR TITLE
Add PDF title metadata and window preference

### DIFF
--- a/src/pdf.js
+++ b/src/pdf.js
@@ -96,3 +96,16 @@ export function addOutline(pdf, title, pageRef) {
 
   return itemRef;
 }
+
+/** Set the document title and embed it in XMP metadata. */
+export function setDocumentTitle(pdf, title) {
+  pdf.setTitle(title, { showInWindowTitleBar: true });
+
+  const xmp = `<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>\n<x:xmpmeta xmlns:x="adobe:ns:meta/">\n <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">\n  <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/">\n   <dc:title><rdf:Alt><rdf:li xml:lang="x-default">${title}</rdf:li></rdf:Alt></dc:title>\n  </rdf:Description>\n </rdf:RDF>\n</x:xmpmeta>\n<?xpacket end="w"?>`;
+
+  const metadata = pdf.context.stream(xmp, {
+    Type: "Metadata",
+    Subtype: "XML",
+  });
+  pdf.catalog.set(PDFName.of("Metadata"), pdf.context.register(metadata));
+}

--- a/src/workflows/summaries.js
+++ b/src/workflows/summaries.js
@@ -1,5 +1,5 @@
 import { PDFDocument } from "pdf-lib";
-import { extractTextPerPage, addOutline } from "../pdf.js";
+import { extractTextPerPage, addOutline, setDocumentTitle } from "../pdf.js";
 import { chat } from "../ai.js";
 
 const MODEL = "gpt-4.1-nano";
@@ -18,7 +18,7 @@ const page = pdf.getPages()[i];
   addOutline(pdf, `Pg ${i + 1}: ${summary}`, page.ref);
 }
 
-pdf.setTitle("Remediated PDF");
+setDocumentTitle(pdf, "Remediated PDF");
 pdf.setSubject("Accessibility-enhanced PDF");
 pdf.setKeywords(["accessibility", "alt-text", "PDF remediation"]);
 pdf.setLanguage("en-US");


### PR DESCRIPTION
## Summary
- ensure document title is written to XMP metadata
- show PDF title in viewer window via viewer preference

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1be58d7cc8331b3905c0a57dde398